### PR TITLE
增加实体生成命令

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# devtool-plugin
+esd-projects 插件，支持生成实体类
+
+```$xslt
+Description:
+  Entity generator
+
+Usage:
+  entity [options] [--] [<pool>]
+
+Arguments:
+  pool                       database db pool? [default: "default"]
+
+Options:
+  -t, --table[=TABLE]        database table name? (multiple values allowed)
+      --path[=PATH]          generate entity file path? [default: "@app/Model/Entity"]
+      --template[=TEMPLATE]  generate entity template path? [default: "@devtool/resources"]
+      --extend[=EXTEND]      generate extend class? [default: "\ESD\Plugins\Console\Model\GoModel"]
+  -y, --confirm              confirm execution?
+  -h, --help                 Display this help message
+  -q, --quiet                Do not output any message
+  -V, --version              Display this application version
+      --ansi                 Force ANSI output
+      --no-ansi              Disable ANSI output
+  -n, --no-interaction       Do not ask any interactive question
+  -v|vv|vvv, --verbose       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+```
+例子：
+```$xslt
+php start_server.php entity -t user -y
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# devtool-plugin
+# console-plugin
 esd-projects 插件，支持生成实体类
 
 ```$xslt

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
   "require": {
     "symfony/console": "^4.2",
-    "esd/esd-core": "~0.1"
+    "esd/esd-core": "~0.1",
+    "text/template": "~2.3"
   },
   "require-dev": {
     "esd/esd-co-server": "~0.1"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
     }
   ],
   "name": "esd/console-plugin",
-  "version": "0.1.0",
   "type": "library",
   "keywords": [
     "esd",

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     }
   ],
   "name": "esd/console-plugin",
+  "version": "0.1.0",
   "type": "library",
   "keywords": [
     "esd",

--- a/src/Console/Command/EntityCmd.php
+++ b/src/Console/Command/EntityCmd.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Elite
+ * Date: 2019/7/14
+ * Time: 15:48
+ */
+
+namespace ESD\Plugins\Console\Command;
+
+use ESD\Plugins\Console\Model\Logic\SchemaLogic;
+use ESD\Core\Context\Context;
+use ESD\Core\DI\DI;
+use ESD\Core\Plugins\Config\ConfigContext;
+use ESD\Plugins\Console\ConsolePlugin;
+use ESD\Plugins\Mysql\GetMysql;
+use ESD\Plugins\Mysql\MysqlConfig;
+use ESD\Plugins\Mysql\MysqliDb;
+use ESD\Plugins\Mysql\MysqlOneConfig;
+use ESD\Plugins\Mysql\MysqlPlugin;
+use ESD\Server\Co\Server;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Class EntityCmd
+ * @package ESD\Plugins\Console\Command
+ */
+class EntityCmd extends Command
+{
+    use GetMysql;
+
+    /**
+     * @var Context
+     */
+    private $context;
+
+    /**
+     * StartCmd constructor.
+     * @param Context $context
+     */
+    public function __construct(Context $context)
+    {
+        parent::__construct();
+        $this->context = $context;
+    }
+
+    protected function configure()
+    {
+        $this->setName('entity')->setDescription("Entity generator");
+        $this->addArgument('pool', InputArgument::OPTIONAL, 'database db pool?', 'default');
+        $this->addOption('table', 't', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'database table name?', []);
+        $this->addOption('path', 'p', InputOption::VALUE_OPTIONAL, 'generate entity file path?', '@app/Model/Entity');
+        $this->addOption('template', 'a', InputOption::VALUE_OPTIONAL, '"generate entity template path?', '@devtool/resources');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|null
+     * @throws \ESD\Core\Exception
+     * @throws \ESD\Plugins\Mysql\MysqlException
+     * @throws \ReflectionException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $pool = $input->getArgument('pool');
+        $tables = $input->getOption('table');
+        $path = $input->getOption('path');
+        $tpl = $input->getOption('template');
+
+        $schemaLogic = new SchemaLogic($pool);
+        $schemaLogic->create($path, $tpl, $tables);
+//        var_dump($c);
+
+
+//        if (!$table) {
+
+//        }
+//
+//        $serverConfig = Server::$instance->getServerConfig();
+//        $server_name = $serverConfig->getName();
+//        $master_pid = exec("ps -ef | grep $server_name-master | grep -v 'grep ' | awk '{print $2}'");
+//        if (!empty($master_pid)) {
+//            $io->warning("server $server_name is running");
+//            return ConsolePlugin::SUCCESS_EXIT;
+//        }
+//        if ($input->getOption('clearCache')) {
+//            $io->note("清除缓存文件");
+//            $serverConfig = Server::$instance->getServerConfig();
+//            if (file_exists($serverConfig->getCacheDir() . "/aop")) {
+//                clearDir($serverConfig->getCacheDir() . "/aop");
+//            }
+//            if (file_exists($serverConfig->getCacheDir() . "/di")) {
+//                clearDir($serverConfig->getCacheDir() . "/di");
+//            }
+//            if (file_exists($serverConfig->getCacheDir() . "/proxies")) {
+//                clearDir($serverConfig->getCacheDir() . "/proxies");
+//            }
+//        }
+//        //是否是守护进程
+//        if ($input->getOption('daemonize')) {
+//            $serverConfig = Server::$instance->getServerConfig();
+//            $serverConfig->setDaemonize(true);
+//            $io->note("Input php Start.php stop to quit. Start success.");
+//        } else {
+//            $io->note("Press Ctrl-C to quit. Start success.");
+//        }
+        return ConsolePlugin::SUCCESS_EXIT;
+    }
+
+    /**
+     * @param string $mapping
+     * @param bool   $ucFirst
+     *
+     * @return string
+     */
+    private function getSafeMappingName(string $mapping, bool $ucFirst = false)
+    {
+        $mapping = preg_replace("#[^\w|^\u{4E00}-\u{9FA5}]+#is", '', $mapping);
+        $first   = $mapping ? mb_substr($mapping, 0, 1) : '';
+        if ($first && !preg_match("#[^[A-Za-z_]|^\u{4E00}-\u{9FA5}]+#is", $first)) {
+            $value = str_replace(['-', '_'], ' ', $mapping);
+            $mapping = str_replace(' ', '', ucwords($value));
+            return $ucFirst ? ucfirst($mapping) : $mapping;
+        }
+        if (empty($first)) {
+            return $ucFirst ? 'Db' . mt_rand(1, 100) : 'db' . mt_rand(100, 1000);
+        }
+        return $ucFirst ? 'Db' . $mapping : 'db' . $mapping;
+    }
+}

--- a/src/Console/Command/EntityCmd.php
+++ b/src/Console/Command/EntityCmd.php
@@ -1,24 +1,10 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Elite
- * Date: 2019/7/14
- * Time: 15:48
- */
-
 namespace ESD\Plugins\Console\Command;
 
 use ESD\Plugins\Console\Model\Logic\SchemaLogic;
 use ESD\Core\Context\Context;
-use ESD\Core\DI\DI;
-use ESD\Core\Plugins\Config\ConfigContext;
 use ESD\Plugins\Console\ConsolePlugin;
 use ESD\Plugins\Mysql\GetMysql;
-use ESD\Plugins\Mysql\MysqlConfig;
-use ESD\Plugins\Mysql\MysqliDb;
-use ESD\Plugins\Mysql\MysqlOneConfig;
-use ESD\Plugins\Mysql\MysqlPlugin;
-use ESD\Server\Co\Server;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -26,19 +12,13 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-/**
- * Class EntityCmd
- * @package ESD\Plugins\Console\Command
- */
 class EntityCmd extends Command
 {
     use GetMysql;
-
     /**
      * @var Context
      */
     private $context;
-
     /**
      * StartCmd constructor.
      * @param Context $context
@@ -48,16 +28,16 @@ class EntityCmd extends Command
         parent::__construct();
         $this->context = $context;
     }
-
     protected function configure()
     {
         $this->setName('entity')->setDescription("Entity generator");
         $this->addArgument('pool', InputArgument::OPTIONAL, 'database db pool?', 'default');
         $this->addOption('table', 't', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'database table name?', []);
-        $this->addOption('path', 'p', InputOption::VALUE_OPTIONAL, 'generate entity file path?', '@app/Model/Entity');
-        $this->addOption('template', 'a', InputOption::VALUE_OPTIONAL, '"generate entity template path?', '@devtool/resources');
+        $this->addOption('path', null, InputOption::VALUE_OPTIONAL, 'generate entity file path?', '@app/Model/Entity');
+        $this->addOption('template', null, InputOption::VALUE_OPTIONAL, 'generate entity template path?', '@devtool/resources');
+        $this->addOption('extend', null, InputOption::VALUE_OPTIONAL, 'generate extend class?', '\\ESD\\Go\\GoModel');
+        $this->addOption('confirm', 'y', InputOption::VALUE_NONE, 'confirm execution?');
     }
-
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
@@ -73,65 +53,10 @@ class EntityCmd extends Command
         $tables = $input->getOption('table');
         $path = $input->getOption('path');
         $tpl = $input->getOption('template');
-
-        $schemaLogic = new SchemaLogic($pool);
-        $schemaLogic->create($path, $tpl, $tables);
-//        var_dump($c);
-
-
-//        if (!$table) {
-
-//        }
-//
-//        $serverConfig = Server::$instance->getServerConfig();
-//        $server_name = $serverConfig->getName();
-//        $master_pid = exec("ps -ef | grep $server_name-master | grep -v 'grep ' | awk '{print $2}'");
-//        if (!empty($master_pid)) {
-//            $io->warning("server $server_name is running");
-//            return ConsolePlugin::SUCCESS_EXIT;
-//        }
-//        if ($input->getOption('clearCache')) {
-//            $io->note("清除缓存文件");
-//            $serverConfig = Server::$instance->getServerConfig();
-//            if (file_exists($serverConfig->getCacheDir() . "/aop")) {
-//                clearDir($serverConfig->getCacheDir() . "/aop");
-//            }
-//            if (file_exists($serverConfig->getCacheDir() . "/di")) {
-//                clearDir($serverConfig->getCacheDir() . "/di");
-//            }
-//            if (file_exists($serverConfig->getCacheDir() . "/proxies")) {
-//                clearDir($serverConfig->getCacheDir() . "/proxies");
-//            }
-//        }
-//        //是否是守护进程
-//        if ($input->getOption('daemonize')) {
-//            $serverConfig = Server::$instance->getServerConfig();
-//            $serverConfig->setDaemonize(true);
-//            $io->note("Input php Start.php stop to quit. Start success.");
-//        } else {
-//            $io->note("Press Ctrl-C to quit. Start success.");
-//        }
+        $extendClass = $input->getOption('extend');
+        $confirm = $input->getOption('confirm');
+        $schemaLogic = new SchemaLogic($pool, $io);
+        $schemaLogic->create($path, $tpl, $tables, $extendClass, $confirm);
         return ConsolePlugin::SUCCESS_EXIT;
-    }
-
-    /**
-     * @param string $mapping
-     * @param bool   $ucFirst
-     *
-     * @return string
-     */
-    private function getSafeMappingName(string $mapping, bool $ucFirst = false)
-    {
-        $mapping = preg_replace("#[^\w|^\u{4E00}-\u{9FA5}]+#is", '', $mapping);
-        $first   = $mapping ? mb_substr($mapping, 0, 1) : '';
-        if ($first && !preg_match("#[^[A-Za-z_]|^\u{4E00}-\u{9FA5}]+#is", $first)) {
-            $value = str_replace(['-', '_'], ' ', $mapping);
-            $mapping = str_replace(' ', '', ucwords($value));
-            return $ucFirst ? ucfirst($mapping) : $mapping;
-        }
-        if (empty($first)) {
-            return $ucFirst ? 'Db' . mt_rand(1, 100) : 'db' . mt_rand(100, 1000);
-        }
-        return $ucFirst ? 'Db' . $mapping : 'db' . $mapping;
     }
 }

--- a/src/Console/Command/EntityCmd.php
+++ b/src/Console/Command/EntityCmd.php
@@ -35,7 +35,7 @@ class EntityCmd extends Command
         $this->addOption('table', 't', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'database table name?', []);
         $this->addOption('path', null, InputOption::VALUE_OPTIONAL, 'generate entity file path?', '@app/Model/Entity');
         $this->addOption('template', null, InputOption::VALUE_OPTIONAL, 'generate entity template path?', '@devtool/resources');
-        $this->addOption('extend', null, InputOption::VALUE_OPTIONAL, 'generate extend class?', '\\ESD\\Go\\GoModel');
+        $this->addOption('extend', null, InputOption::VALUE_OPTIONAL, 'generate extend class?', '\\ESD\\Plugins\\Console\\Model\\GoModel');
         $this->addOption('confirm', 'y', InputOption::VALUE_NONE, 'confirm execution?');
     }
     /**

--- a/src/Console/ConsolePlugin.php
+++ b/src/Console/ConsolePlugin.php
@@ -10,6 +10,7 @@ namespace ESD\Plugins\Console;
 
 use ESD\Core\Context\Context;
 use ESD\Core\PlugIn\AbstractPlugin;
+use ESD\Plugins\Console\Command\EntityCmd;
 use ESD\Plugins\Console\Command\ReloadCmd;
 use ESD\Plugins\Console\Command\RestartCmd;
 use ESD\Plugins\Console\Command\StartCmd;
@@ -70,6 +71,7 @@ class ConsolePlugin extends AbstractPlugin
         $this->config->addCmdClass(RestartCmd::class);
         $this->config->addCmdClass(StartCmd::class);
         $this->config->addCmdClass(StopCmd::class);
+        $this->config->addCmdClass(EntityCmd::class);
         $this->config->merge();
         $cmds = [];
         foreach ($this->config->getCmdClassList() as $value) {

--- a/src/Console/FileGen.php
+++ b/src/Console/FileGen.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Elite
+ * Date: 2019/7/14
+ * Time: 15:48
+ */
+
+namespace ESD\Plugins\Console;
+
+use Leuffen\TextTemplate\TextTemplate;
+
+class FileGen
+{
+    /**
+     * @var string
+     */
+    private $tplDir;
+    /**
+     * @var string
+     */
+    private $tplName;
+    /**
+     * @var string
+     */
+    private $tplSuffix;
+
+    private $parser;
+
+    public function __construct(string $tplDir, string $tplName, string $tplSuffix = '.stub')
+    {
+        $this->tplDir = $tplDir;
+        $this->tplName = $tplName;
+        $this->tplSuffix = $tplSuffix;
+        $this->parser = new TextTemplate();
+    }
+
+    /**
+     * @param array $data
+     * @return string
+     * @throws \Exception
+     */
+    public function render (array $data = []) {
+        $tplFile = $this->getTplFile();
+
+        $text = $this->parser
+            ->loadTemplate(file_get_contents($tplFile))
+            ->apply($data);
+
+        return $text;
+    }
+
+    /**
+     * @param string $file
+     * @param array $data
+     * @return bool
+     * @throws \Exception
+     */
+    public function renderAs (string $file, array $data = []) {
+        $text = $this->render($data);
+        return file_put_contents($file, $text) > 0;
+    }
+
+    /**
+     * @return string
+     * @throws \Exception
+     */
+    public function getTplFile()
+    {
+        $file = rtrim($this->tplDir, '/\\') . '/' . $this->tplName . $this->tplSuffix;
+        if (!file_exists($file)) {
+            throw new \Exception("Template file not exists! File: {$file}");
+        }
+        return $file;
+    }
+}

--- a/src/Console/Helper/StringHelper.php
+++ b/src/Console/Helper/StringHelper.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Elite
+ * Date: 2019/7/1
+ * Time: 12:01
+ */
+
+namespace ESD\Plugins\Console\Helper;
+
+/**
+ * Class StringHelper
+ * @package ESD\Plugins\Console\Helper
+ */
+class StringHelper
+{
+    public static function camel2Snake($var)
+    {
+        if (is_numeric($var)) {
+            return $var;
+        }
+        $result = "";
+        for ($i = 0; $i < strlen($var); $i++) {
+            $str = ord($var[$i]);
+            if ($str > 64 && $str < 91) {
+                $result .= "_" . strtolower($var[$i]);
+            } else {
+                $result .= $var[$i];
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * "_"连接修改为驼峰
+     * @param $var
+     * @return mixed
+     */
+    public static function snake2Camel($var)
+    {
+        if (is_numeric($var)) {
+            return $var;
+        }
+        $result = "";
+        for ($i = 0; $i < strlen($var); $i++) {
+            if ($var[$i] == "_") {
+                $i = $i + 1;
+                $result .= strtoupper($var[$i]);
+            } else {
+                $result .= $var[$i];
+            }
+        }
+        return $result;
+    }
+}

--- a/src/Console/Model/Dao/SchemaDao.php
+++ b/src/Console/Model/Dao/SchemaDao.php
@@ -1,0 +1,70 @@
+<?php
+namespace ESD\Plugins\Console\Model\Dao;
+
+use ESD\Plugins\Console\Service\Impl\MysqlBuilder;
+use ESD\Plugins\Mysql\MysqlException;
+
+class SchemaDao
+{
+    /**
+     * @var MysqlBuilder
+     */
+    private $builder;
+
+    /**
+     * SchemaDao constructor.
+     * @param string $pool
+     * @throws MysqlException
+     * @throws \ReflectionException
+     */
+    public function __construct(string $pool)
+    {
+        $this->builder = new MysqlBuilder($pool);
+    }
+
+    /**
+     * @param array $tables
+     * @return array
+     */
+    public function getTableSchema($tables = []): array
+    {
+        $tableSchema = $this->builder->getTableSchema($tables);
+        return $tableSchema;
+    }
+
+    /**
+     * @param string $table
+     * @return array
+     */
+    public function getColumnSchema(string $table): array
+    {
+        $columnSchema = $this->builder->getColumnSchema($table);
+        array_walk($columnSchema, function (&$item) {
+            $nullable = $item['nullable'] == 'YES' || !$item['nullable'];
+            $required = !$nullable && is_null($item['default']);
+            $type = $this->builder->getGrammar()->map[$item['type']];
+            $pubType = $type;
+            $item['required'] = $required;
+            $item['type'] = $type;
+            $item['pubType'] = $pubType;
+            $item['nullable'] = $nullable;
+        });
+        return $columnSchema;
+    }
+
+    /**
+     * @return MysqlBuilder
+     */
+    public function getBuilder(): MysqlBuilder
+    {
+        return $this->builder;
+    }
+
+    /**
+     * @param MysqlBuilder $builder
+     */
+    public function setBuilder(MysqlBuilder $builder): void
+    {
+        $this->builder = $builder;
+    }
+}

--- a/src/Console/Model/GoModel.php
+++ b/src/Console/Model/GoModel.php
@@ -1,0 +1,301 @@
+<?php
+namespace ESD\Plugins\Console\Model;
+
+use ESD\Plugins\Console\Helper\StringHelper;
+use ESD\Plugins\Mysql\GetMysql;
+use ESD\Plugins\Mysql\MysqlException;
+use ESD\Plugins\Mysql\MysqlManyPool;
+use ESD\Plugins\Validate\Annotation\Filter;
+use ESD\Plugins\Validate\Annotation\Validated;
+use ESD\Plugins\Validate\ValidationException;
+use ESD\Psr\Tracing\TracingInterface;
+use Inhere\Validate\Validation;
+
+abstract class GoModel extends Validation implements TracingInterface
+{
+    use GetMysql;
+
+    /**
+     * @var array
+     */
+    private static $modelReflectionClass = [];
+    /**
+     * @var \ReflectionClass
+     */
+    private $_reflectionClass;
+
+    /**
+     * @var bool
+     */
+    private $isNewRecord = true;
+
+    /**
+     * Model constructor.
+     * @param array $data
+     * @param array $rules
+     * @param array $translates
+     * @param string $scene
+     * @throws \ReflectionException
+     */
+    public function __construct(array $data = [], array $rules = [], array $translates = [], string $scene = '')
+    {
+        parent::__construct($data, $rules, $translates, $scene);
+        if (array_key_exists(static::class, self::$modelReflectionClass) && self::$modelReflectionClass[static::class] != null) {
+            $this->_reflectionClass = self::$modelReflectionClass[static::class];
+        } else {
+            $this->_reflectionClass = new \ReflectionClass(static::class);
+            self::$modelReflectionClass[static::class] = $this->_reflectionClass;
+        }
+        $this->isNewRecord = !$data;
+        $this->load($data);
+    }
+
+    /**
+     * @return array
+     * @throws \DI\DependencyException
+     * @throws \DI\NotFoundException
+     * @throws \ReflectionException
+     */
+    public function rules(): array
+    {
+        return Validated::buildRole($this->_reflectionClass);
+    }
+
+    /**
+     * @param $array
+     */
+    public function load ($array) {
+        if (empty($array)) return;
+        $sceneFields = $this->getSceneFields();
+        //转换key格式
+        $data = [];
+        foreach ($array as $key => $value) {
+            if ($sceneFields && !in_array($key, $sceneFields)) continue;
+            $data[StringHelper::snake2Camel($key)] = $value;
+        }
+        $filterData = Filter::filter($this->_reflectionClass, $data);
+        foreach ($filterData as $key => $value) {
+            if ($this->_reflectionClass->hasProperty($key)) {
+                $reflectionProperty = $this->_reflectionClass->getProperty($key);
+                if ($reflectionProperty->isPublic()) {
+                    $this->$key = $value;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array $include
+     * @throws ValidationException
+     */
+    public function validated($include = []) {
+        if ($this->validate($include)->failed()) {
+            throw new ValidationException($this->firstError());
+        }
+    }
+
+    /**
+     * @param bool $ignoreNull
+     * @param bool $camel2Snake
+     * @param array $include
+     * @param array $exclude
+     * @return array
+     */
+    public function toArray($ignoreNull = true, $camel2Snake = true, $include = [], $exclude = [])
+    {
+        $array = [];
+        foreach ($this->_reflectionClass->getProperties() as $reflectionProperty) {
+            if ($reflectionProperty->isPublic()) {
+                $key = $reflectionProperty->name;
+                $value = $this->$key;
+                if (is_array($value) || is_object($value)) continue;
+                if ($ignoreNull && $value === null) continue;
+                if ($include && !in_array($key, $include)) continue;
+                if ($exclude && in_array($key, $exclude)) continue;
+                if ($camel2Snake) {
+                    $array[StringHelper::camel2Snake($key)] = $value;
+                } else {
+                    $array[$key] = $value;
+                }
+            }
+        }
+        return $array;
+    }
+
+    /**
+     * @param $selectDb
+     * @return \ESD\Plugins\Mysql\MysqliDb|mixed
+     * @throws MysqlException
+     */
+    private static function Db($selectDb) {
+        $name = $selectDb;
+        $db = getContextValue("MysqliDb:$name");
+        if ($db == null) {
+            $mysqlPool = getDeepContextValueByClassName(MysqlManyPool::class);
+            if ($mysqlPool instanceof MysqlManyPool) {
+                $db = $mysqlPool->getPool($name)->db();
+            } else {
+                throw new MysqlException("没有找到名为{$name}的mysql连接池");
+            }
+        }
+        return $db;
+    }
+
+    /**
+     * @param $condition
+     * @param string $selectDb
+     * @return GoModel|null
+     * @throws MysqlException
+     * @throws \ReflectionException
+     */
+    public static function findOne($condition, $selectDb = 'default') {
+        $query = self::Db($selectDb);
+        if (!is_array($condition)) {
+            $query->where(static::getPrimaryKey(), $condition);
+        } else {
+            foreach ($condition as $cond) {
+                $query->where(...$cond);
+            }
+        }
+        $result = $query->get(static::getTableName(), 1)[0] ?? null;
+        if ($result == null) {
+            return null;
+        } else {
+            return new static($result);
+        }
+    }
+
+    /**
+     * @param array $condition
+     * @param string $selectDb
+     * @return array
+     * @throws MysqlException
+     * @throws \ReflectionException
+     */
+    public static function findAll(array $condition, $selectDb = 'default') {
+        $query = self::Db($selectDb);
+        foreach ($condition as $cond) {
+            $query->where(...$cond);
+        }
+        $result = $query->get(static::getTableName()) ?? [];
+        foreach ($result as $key => $one) {
+            $result[$key] = new static($one);
+        }
+        return $result;
+    }
+
+    /**
+     * @param bool $forcePrimaryKey
+     * @return array|\stdClass
+     * @throws ValidationException
+     */
+    public function validatedData($forcePrimaryKey = false)
+    {
+        $this->data = $this->toArray(true, true);
+        if ($forcePrimaryKey) {
+            $this->setRules([[static::getPrimaryKey(), 'required']]);
+            $sceneFields = $this->getSceneFields();
+            if ($sceneFields && !in_array(static::getPrimaryKey(), $sceneFields)) {
+                $sceneFields[] = static::getPrimaryKey();
+                $this->validated($sceneFields);
+            } else {
+                $this->validated($sceneFields);
+            }
+        } else {
+            $this->validated();
+        }
+        return $this->getSafeData();
+    }
+
+    /**
+     * @param string $selectDb
+     * @return bool
+     * @throws MysqlException
+     * @throws ValidationException
+     */
+    public function update($selectDb = 'default') {
+        // Update load data rather then safe data.
+        $this->validatedData(true);
+        $pk = $this->getPrimaryKey();
+        return $this->mysql($selectDb)
+            ->where($pk, $this->$pk)
+            ->update($this->getTableName(), $this->data);
+    }
+
+    /**
+     * @param string $selectDb
+     * @return bool
+     * @throws MysqlException
+     * @throws ValidationException
+     */
+    public function replace($selectDb = 'default') {
+        // Replace load data rather then safe data.
+        $this->validatedData(true);
+        $pk = $this->getPrimaryKey();
+        return $this->mysql($selectDb)
+            ->where($pk, $this->$pk)
+            ->replace($this->getTableName(), $this->data);
+    }
+
+    /**
+     * @param string $selectDb
+     * @throws MysqlException
+     * @throws ValidationException
+     */
+    public function insert($selectDb = 'default') {
+        // Insert load data rather then safe data.
+        $this->validatedData(false);
+        $id = $this->mysql($selectDb)
+            ->insert($this->getTableName(), $this->data);
+        if ($id === false) {
+            throw new MysqlException($this->mysql($selectDb)->getLastError(), $this->mysql($selectDb)->getLastErrno());
+        }
+        $pk = $this->getPrimaryKey();
+        $this->$pk = $id;
+    }
+
+    /**
+     * @param string $selectDb
+     * @return bool
+     * @throws MysqlException
+     * @throws ValidationException
+     */
+    public function save($selectDb = 'default') {
+        if (!$this->isNewRecord) {
+            return $this->update($selectDb);
+        }
+        $this->insert($selectDb);
+        return true;
+    }
+
+    /**
+     * @param string $selectDb
+     * @return bool
+     * @throws MysqlException
+     */
+    public function delete($selectDb = 'default') {
+        $pk = $this->getPrimaryKey();
+        return $this->mysql($selectDb)
+            ->where($pk, $this->$pk)
+            ->delete($this->getTableName());
+    }
+
+    /**
+     * @return bool
+     */
+    public function isNewRecord(): bool
+    {
+        return $this->isNewRecord;
+    }
+
+    /**
+     * @param bool $isNewRecord
+     */
+    public function setIsNewRecord(bool $isNewRecord): void
+    {
+        $this->isNewRecord = $isNewRecord;
+    }
+
+    abstract public static function getPrimaryKey(): string;
+    abstract public static function getTableName(): string;
+}

--- a/src/Console/Model/GoModel.php
+++ b/src/Console/Model/GoModel.php
@@ -63,6 +63,7 @@ abstract class GoModel extends Validation implements TracingInterface
 
     /**
      * @param $array
+     * @throws \ReflectionException
      */
     public function load ($array) {
         if (empty($array)) return;

--- a/src/Console/Model/Logic/SchemaLogic.php
+++ b/src/Console/Model/Logic/SchemaLogic.php
@@ -1,0 +1,138 @@
+<?php
+namespace ESD\Plugins\Console\Model\Logic;
+
+use ESD\Plugins\Console\FileGen;
+use ESD\Plugins\Console\Model\Dao\SchemaDao;
+use ESD\Core\Exception;
+use phpDocumentor\Reflection\Types\String_;
+
+class SchemaLogic
+{
+    const CREATED_AT = 'created_at';
+    const UPDATED_AT = 'updated_at';
+
+    /**
+     * @var SchemaDao
+     */
+    protected $schemaDao;
+
+    /**
+     * SchemaLogic constructor.
+     * @param string $pool
+     * @throws \ESD\Plugins\Mysql\MysqlException
+     * @throws \ReflectionException
+     */
+    public function __construct(string $pool)
+    {
+        $this->schemaDao = new SchemaDao($pool);
+    }
+
+    public function alias ($alias) {
+        if (strpos($alias, '@elite') === 0) {
+            return str_replace('@elite', ROOT_DIR . '/src', $alias);
+        }
+        if (strpos($alias, '@res') === 0) {
+            return str_replace('@res', RES_DIR, $alias);
+        }
+        if (strpos($alias, '@devtool') === 0) {
+            return str_replace('@devtool', dirname(__DIR__, 2), $alias);
+        }
+        return $alias;
+    }
+
+    /**
+     * @param string $path
+     * @param string $template
+     * @param array $tables
+     * @throws Exception
+     * @throws \Exception
+     */
+    public function create ($path = '', $template = '', array $tables = []) {
+        $template = $this->alias($template);
+        if (!is_dir($template)) {
+            throw new Exception("Template[{$template}] not found");
+        }
+        if (strpos($path, '@elite/') === 0) {
+            $namespace = str_replace('/', '\\', str_replace('@elite', 'Elite', $path));
+        } else {
+            $namespace = 'Elite\\Common\\Model\\Entity';
+        }
+        $path = $this->alias($path);
+        if (!is_dir($path)) mkdir($path, 0777, true);
+        $tables = $this->schemaDao->getTableSchema($tables);
+        foreach ($tables as $table) {
+            $this->generateEntity($path, $template, $table, $namespace);
+            die;
+        }
+    }
+
+    /**
+     * @param string $path
+     * @param string $template
+     * @param array $table
+     * @param string $namespace
+     * @return string
+     * @throws \Exception
+     */
+    public function generateEntity (string $path, string $template, array $table, string $namespace) {
+        $columnSchemas = $this->schemaDao->getColumnSchema($table['name']);
+        $genProperties = [];
+        $genTranslates = [];
+        $primary = '';
+        foreach ($columnSchemas as $columnSchema) {
+            if ($columnSchema['key'] === 'PRI') $primary = $columnSchema['name'];
+            $genProperties[] = $this->generateProperties($columnSchema, $template);
+            $genTranslates[] = "            '{$columnSchema['name']}' => '{$columnSchema['columnComment']}',";
+        }
+        $prefix = $this->schemaDao->getBuilder()->getMysqlConfig()->getPrefix();
+        $tableName = substr($table['name'], strlen($prefix));
+        $entityName = str_replace(['-', '_'], ' ', $tableName);
+        $entityName = str_replace(' ', '', ucwords($entityName));
+        $file = sprintf('%s/%s.php', $path, $entityName);
+        $data = [
+            'entityName' => $entityName,
+            'namespace' => $namespace,
+            'tableComment' => $table['comment'],
+            'tableName' => $tableName,
+            'primaryKey' => $primary,
+            'properties' => implode(PHP_EOL, $genProperties),
+            'translates' => implode(PHP_EOL, $genTranslates),
+        ];
+        $gen = new FileGen($template, 'entity');
+//        return $gen->render($data);
+        return $gen->renderAs($file, $data);
+    }
+
+    /**
+     * @param $columnSchema
+     * @param $template
+     * @return string
+     * @throws \Exception
+     */
+    public function generateProperties($columnSchema, $template) {
+        $validated = [];
+        if ($columnSchema['required'] &&
+            $columnSchema['extra'] !== 'auto_increment' &&
+            !in_array($columnSchema['name'], [
+                self::CREATED_AT,
+                self::UPDATED_AT
+            ])) $validated[] = 'required=true';
+        $validated[] = "{$columnSchema['pubType']}=true";
+        if ($columnSchema['length']) $validated[] = "max={$columnSchema['length']}";
+        $propertyName = $columnSchema['name'];
+        for ($i = 0; $i < strlen($propertyName); $i++) {
+            if ($propertyName[$i] === '_') {
+                $propertyName[$i+1] = strtoupper($propertyName[$i+1]);
+            }
+        }
+        $propertyName = str_replace('_', '', $propertyName);
+        $data = [
+            'type' => $columnSchema['type'],
+            'validated' => implode(', ', $validated),
+            'comment' => $columnSchema['columnComment'],
+            'propertyName' => $propertyName
+        ];
+        $gen = new FileGen($template, 'property');
+        return $gen->render($data);
+    }
+}

--- a/src/Console/Service/Builder.php
+++ b/src/Console/Service/Builder.php
@@ -1,0 +1,6 @@
+<?php
+namespace ESD\Plugins\Console\Service;
+
+abstract class Builder
+{
+}

--- a/src/Console/Service/Grammar.php
+++ b/src/Console/Service/Grammar.php
@@ -1,0 +1,16 @@
+<?php
+namespace ESD\Plugins\Console\Service;
+
+abstract class Grammar
+{
+    /**
+     * @var string
+     */
+    public const INTEGER  = 'integer';
+    public const NUMBER   = 'number';
+    public const STRING   = 'string';
+    public const FLOAT    = 'float';
+    public const DATETIME = 'datetime';
+    public const BOOLEAN  = 'boolean';
+    public const BOOL     = 'bool';
+}

--- a/src/Console/Service/Impl/MysqlBuilder.php
+++ b/src/Console/Service/Impl/MysqlBuilder.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace ESD\Plugins\Console\Service\Impl;
+
+use ESD\Core\Server\Server;
+use ESD\Plugins\Mysql\MysqlException;
+use ESD\Plugins\Mysql\MysqliDb;
+use ESD\Plugins\Mysql\MysqlOneConfig;
+
+class MysqlBuilder
+{
+    /**
+     * @var MysqliDb
+     */
+    private $mysql;
+
+    /**
+     * @var MysqlGrammar
+     */
+    private $grammar;
+
+    /**
+     * @var MysqlOneConfig
+     */
+    private $mysqlConfig;
+
+    /**
+     * MysqlBuilder constructor.
+     * @param $pool
+     * @throws MysqlException
+     * @throws \ReflectionException
+     */
+    public function __construct($pool)
+    {
+        $configs = Server::$instance->getConfigContext()->get(MysqlOneConfig::key, []);
+        if (!isset($configs[$pool])) {
+            throw new MysqlException("The pool[{$pool}] not found!");
+        }
+        $mysqlOneConfig = new MysqlOneConfig('', '', '', '');
+        $mysqlOneConfig->setName($pool);
+        $mysqlOneConfig = $mysqlOneConfig->buildFromConfig($configs[$pool]);
+        $this->mysql = new MysqliDb($mysqlOneConfig->buildConfig());
+        $this->mysqlConfig = $mysqlOneConfig;
+        $this->grammar = new MysqlGrammar();
+    }
+
+    /**
+     * @return string
+     */
+    public function getDatabaseName () {
+        return $this->mysqlConfig->getDb();
+    }
+
+    /**
+     * @param string $table
+     * @return array
+     */
+    public function getColumnSchema(string $table) {
+        $table = trim($table);
+        if (strpos($table, $this->mysqlConfig->getPrefix()) !== 0) {
+            $table = "`{$this->mysqlConfig->getPrefix()}{$table}`";
+        }
+        return $this->mysql
+            ->where('table_schema', $this->getDatabaseName())
+            ->where('table_name', $table)
+            ->get('information_schema.columns', null, [
+                'COLUMN_NAME as `name`',
+                'DATA_TYPE as `type`',
+                'COLUMN_DEFAULT as `default`',
+                'COLUMN_KEY as `key`',
+                'IS_NULLABLE as `nullable`',
+                'COLUMN_TYPE as `columnType`',
+                'COLUMN_COMMENT as `columnComment`',
+                'CHARACTER_MAXIMUM_LENGTH as `length`',
+                'EXTRA as extra'
+            ]);
+    }
+
+    /**
+     * @param array $tables
+     * @return array
+     */
+    public function getTableSchema(array $tables) {
+        array_walk($tables, function (&$table) {
+            $table = trim($table);
+            if (strpos($table, $this->mysqlConfig->getPrefix()) !== 0) {
+                $table = "`{$this->mysqlConfig->getPrefix()}{$table}`";
+            }
+        });
+        $query = $this->mysql
+            ->where('table_schema', $this->getDatabaseName())
+            ->where('table_type', 'BASE TABLE');
+        if ($tables) {
+            $query->where('table_name', $tables, 'in');
+        } else {
+            $query->where('table_name', $this->mysqlConfig->getPrefix() . '%', 'like');
+        }
+        return $query->get('information_schema.tables', null, [
+            'TABLE_NAME as name', 'TABLE_COMMENT as comment'
+        ]);
+    }
+
+    /**
+     * @return MysqlGrammar
+     */
+    public function getGrammar(): MysqlGrammar
+    {
+        return $this->grammar;
+    }
+
+    /**
+     * @param MysqlGrammar $grammar
+     */
+    public function setGrammar(MysqlGrammar $grammar): void
+    {
+        $this->grammar = $grammar;
+    }
+
+    /**
+     * @return MysqlOneConfig
+     */
+    public function getMysqlConfig(): MysqlOneConfig
+    {
+        return $this->mysqlConfig;
+    }
+
+    /**
+     * @param MysqlOneConfig $mysqlConfig
+     */
+    public function setMysqlConfig(MysqlOneConfig $mysqlConfig): void
+    {
+        $this->mysqlConfig = $mysqlConfig;
+    }
+
+}

--- a/src/Console/Service/Impl/MysqlGrammar.php
+++ b/src/Console/Service/Impl/MysqlGrammar.php
@@ -1,0 +1,53 @@
+<?php
+namespace ESD\Plugins\Console\Service\Impl;
+
+use ESD\Plugins\Console\Service\Grammar;
+
+class MysqlGrammar extends Grammar
+{
+    /**
+     * @var array
+     */
+    public $map = [
+        'tinyint'    => self::INTEGER,
+        'bit'        => self::INTEGER,
+        'smallint'   => self::INTEGER,
+        'mediumint'  => self::INTEGER,
+        'int'        => self::INTEGER,
+        'integer'    => self::INTEGER,
+        'bigint'     => self::INTEGER,
+        'float'      => self::FLOAT,
+        'double'     => self::FLOAT,
+        'real'       => self::FLOAT,
+        'decimal'    => self::FLOAT,
+        'numeric'    => self::FLOAT,
+        'tinytext'   => self::STRING,
+        'mediumtext' => self::STRING,
+        'longtext'   => self::STRING,
+        'longblob'   => self::STRING,
+        'blob'       => self::STRING,
+        'text'       => self::STRING,
+        'varchar'    => self::STRING,
+        'string'     => self::STRING,
+        'char'       => self::STRING,
+        'datetime'   => self::STRING,
+        'year'       => self::STRING,
+        'date'       => self::STRING,
+        'time'       => self::STRING,
+        'timestamp'  => self::STRING,
+        'enum'       => self::STRING,
+        'varbinary'  => self::STRING,
+        'json'       => self::STRING,
+    ];
+
+    /**
+     * Compile the SQL needed to retrieve all table names.
+     *
+     * @return string
+     */
+    public function compileGetAllTables(): string
+    {
+        return 'SHOW FULL TABLES WHERE table_type = \'BASE TABLE\'';
+    }
+
+}

--- a/src/Console/resources/entity.stub
+++ b/src/Console/resources/entity.stub
@@ -3,14 +3,13 @@ namespace {= namespace};
 
 use ESD\Plugins\Validate\Annotation\Filter;
 use ESD\Plugins\Validate\Annotation\Validated;
-use ESD\Plugins\Console\Model\GoModel;
 
 /**
  * {= tableComment}
  *
  * Class {= entityName}
  */
-class {= entityName} extends GoModel
+class {= entityName} extends {= extendClass}
 {
 
 {= properties | raw }

--- a/src/Console/resources/entity.stub
+++ b/src/Console/resources/entity.stub
@@ -1,0 +1,44 @@
+<?php
+namespace {= namespace};
+
+use ESD\Plugins\Validate\Annotation\Filter;
+use ESD\Plugins\Validate\Annotation\Validated;
+use ESD\Plugins\Console\Model\GoModel;
+
+/**
+ * {= tableComment}
+ *
+ * Class {= entityName}
+ */
+class {= entityName} extends GoModel
+{
+
+{= properties | raw }
+
+    public function translates(): array
+    {
+        return [
+{= translates | raw }
+        ];
+    }
+
+    /**
+     * 获取数据库表名
+     *
+     * @return string
+     */
+    public static function getTableName(): string
+    {
+        return "{= tableName}";
+    }
+
+    /**
+     * 获取主键名
+     *
+     * @return string
+     */
+    public static function getPrimaryKey(): string
+    {
+        return "{= primaryKey}";
+    }
+}

--- a/src/Console/resources/property.stub
+++ b/src/Console/resources/property.stub
@@ -1,0 +1,6 @@
+    /**
+     * {= comment | raw}
+     * @Validated({= validated})
+     * @var {= type}
+     */
+    public ${= propertyName};


### PR DESCRIPTION
```$xslt
Description:
  Entity generator

Usage:
  entity [options] [--] [<pool>]

Arguments:
  pool                       database db pool? [default: "default"]

Options:
  -t, --table[=TABLE]        database table name? (multiple values allowed)
      --path[=PATH]          generate entity file path? [default: "@app/Model/Entity"]
      --template[=TEMPLATE]  generate entity template path? [default: "@devtool/resources"]
      --extend[=EXTEND]      generate extend class? [default: "\ESD\Plugins\Console\Model\GoModel"]
  -y, --confirm              confirm execution?
  -h, --help                 Display this help message
  -q, --quiet                Do not output any message
  -V, --version              Display this application version
      --ansi                 Force ANSI output
      --no-ansi              Disable ANSI output
  -n, --no-interaction       Do not ask any interactive question
  -v|vv|vvv, --verbose       Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```
例子：
```$xslt
php start_server.php entity -t user -y
```